### PR TITLE
Properly handle multiple zones

### DIFF
--- a/src/CloudflarePurge.php
+++ b/src/CloudflarePurge.php
@@ -4,36 +4,99 @@ namespace JustBetter\StatamicCloudflarePurge;
 
 use Illuminate\Support\Arr;
 use Illuminate\Support\Facades\Storage;
+use Statamic\Facades\Site;
 
 class CloudflarePurge
 {
-    public static function getInvalidateUrls()
+    public static function getInvalidateUrls(?string $zone = null): array
     {
-        $files = explode("\n", Storage::disk('local')->get('/.cloudflare-invalidate-urls'));
+        $files = explode("\n", Storage::disk('local')->get(static::getStoragePath($zone)) ?? '');
 
         return Arr::where($files, fn ($file) => $file);
     }
 
-    public static function clearInvalidateUrls()
+    public static function clearInvalidateUrls(?string $zone = null): void
     {
-        Storage::disk('local')->delete('/.cloudflare-invalidate-urls');
+        Storage::disk('local')->delete(static::getStoragePath($zone));
+
+        static::removeZone($zone);
     }
 
-    public static function popInvalidateUrls()
+    public static function popInvalidateUrls(?string $zone = null): array
     {
-        $files = static::GetInvalidateUrls();
+        $files = static::GetInvalidateUrls($zone);
 
-        static::ClearInvalidateUrls();
+        static::ClearInvalidateUrls($zone);
 
         return $files;
     }
 
-    public static function appendInvalidateUrl(string $url)
+    public static function appendInvalidateUrl(string $url, ?string $zone = null): void
     {
-        if (in_array($url, static::GetInvalidateUrls())) {
+        if (in_array($url, static::GetInvalidateUrls($zone))) {
             return;
         }
 
-        Storage::disk('local')->append('/.cloudflare-invalidate-urls', $url);
+        Storage::disk('local')->append(static::getStoragePath($zone), $url);
+        
+        static::appendZone($zone);
+    }
+
+    public static function getStoragePath(?string $zone = null): string
+    {
+        if (!$zone) {
+            $zone = static::getCurrentZone();
+        }
+        
+        return '/.cloudflare-invalidate-urls-' . $zone;
+    }
+
+    public static function appendZone(?string $zone = null): void
+    {
+        if (!$zone) {
+            $zone = static::getCurrentZone();
+        }
+
+        if (in_array($zone, static::getZones())) {
+            return;
+        }
+
+        Storage::disk('local')->append('/.cloudflare-invalidate-zones', $zone);
+    }
+
+    public static function removeZone(?string $zone = null): void
+    {
+        if (!$zone) {
+            $zone = static::getCurrentZone();
+        }
+
+        $zones = static::getZones();
+        $id = array_search($zone, $zones);
+
+        if ($id === false) {
+            return;
+        }
+
+        unset($zones[$id]);
+
+        Storage::disk('local')->put('/.cloudflare-invalidate-zones', implode("\n", $zones));
+    }
+
+    public static function getZones(): array
+    {
+        $zones = explode("\n", Storage::disk('local')->get('/.cloudflare-invalidate-zones') ?? '');
+
+        return Arr::where($zones, fn ($zone) => $zone);
+    }
+
+    public static function getCurrentZone(): ?string
+    {
+        $zone = config('cloudflare-purge.zone');
+
+        if (is_array($zone)) {
+            return $zone[Site::current()->handle];
+        }
+
+        return value($zone);
     }
 }

--- a/src/Facades/CloudflarePurge.php
+++ b/src/Facades/CloudflarePurge.php
@@ -5,10 +5,15 @@ namespace JustBetter\StatamicCloudflarePurge\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void appendInvalidateUrl(string $url)
- * @method static array getInvalidateUrls():
- * @method static array popInvalidateUrls():
- * @method static void clearInvalidateUrls():
+ * @method static void appendInvalidateUrl(string $url, ?string $zone)
+ * @method static array getInvalidateUrls(?string $zone)
+ * @method static array popInvalidateUrls(?string $zone)
+ * @method static void clearInvalidateUrls(?string $zone)
+ * @method static string getStoragePath(?string $zone)
+ * @method static void appendZone(?string $zone)
+ * @method static void removeZone(?string $zone)
+ * @method static array getZones()
+ * @method static string getCurrentZone()
  *
  * @see \JustBetter\StatamicCloudflarePurge\CloudflarePurge
  */

--- a/src/Facades/CloudflarePurge.php
+++ b/src/Facades/CloudflarePurge.php
@@ -5,13 +5,13 @@ namespace JustBetter\StatamicCloudflarePurge\Facades;
 use Illuminate\Support\Facades\Facade;
 
 /**
- * @method static void appendInvalidateUrl(string $url, ?string $zone)
- * @method static array getInvalidateUrls(?string $zone)
- * @method static array popInvalidateUrls(?string $zone)
- * @method static void clearInvalidateUrls(?string $zone)
- * @method static string getStoragePath(?string $zone)
- * @method static void appendZone(?string $zone)
- * @method static void removeZone(?string $zone)
+ * @method static void appendInvalidateUrl(string $url, ?string $zone = null)
+ * @method static array getInvalidateUrls(?string $zone = null)
+ * @method static array popInvalidateUrls(?string $zone = null)
+ * @method static void clearInvalidateUrls(?string $zone = null)
+ * @method static string getStoragePath(?string $zone = null)
+ * @method static void appendZone(?string $zone = null)
+ * @method static void removeZone(?string $zone = null)
  * @method static array getZones()
  * @method static string getCurrentZone()
  *

--- a/src/Jobs/PurgeCloudflareCachesJob.php
+++ b/src/Jobs/PurgeCloudflareCachesJob.php
@@ -19,8 +19,10 @@ class PurgeCloudflareCachesJob implements ShouldQueue
             return;
         }
 
-        $files = CloudflarePurge::popInvalidateUrls();
-
-        $cloudflare->purge(everything: $this->all, files: $files);
+        foreach (CloudflarePurge::getZones() as $zone) {
+            $files = CloudflarePurge::popInvalidateUrls($zone);
+            
+            $cloudflare->purge($zone, everything: $this->all, files: $files);
+        }
     }
 }

--- a/src/Listeners/FlushCacheListener.php
+++ b/src/Listeners/FlushCacheListener.php
@@ -2,12 +2,15 @@
 
 namespace JustBetter\StatamicCloudflarePurge\Listeners;
 
+use JustBetter\StatamicCloudflarePurge\Facades\CloudflarePurge;
 use JustBetter\StatamicCloudflarePurge\Jobs\PurgeCloudflareCachesJob;
 
 class FlushCacheListener
 {
     public function handle($event): void
     {
+        CloudflarePurge::appendZone();
+        
         PurgeCloudflareCachesJob::dispatch(true);
     }
 }


### PR DESCRIPTION
In the initial version I seem to have forgotten to actually handle the multiple zones when appending and clearing urls.

Because we're allowing arbitrary zone definitions in the config, we can't just loop over `Statamic\Facades\Site::all()`. So, instead, I've made a file that will contain all the actual zone IDs to purge if necessary, which get removed from the file on a cache purge. The removal is to make sure we don't end up having any old zone IDs that are no longer relevant.