### PR TITLE
Chunk single-file purges based on rate limit

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ composer.lock
 node_modules
 vendor
 .php_cs.cache
+.editorconfig

--- a/README.md
+++ b/README.md
@@ -49,7 +49,7 @@ Schedule::job(\JustBetter\StatamicCloudflarePurge\Jobs\PurgeCloudflareCachesJob:
 ```
 
 > [!NOTE]
-> Be aware of the [rate limits on the API](https://developers.cloudflare.com/cache/how-to/purge-cache/#availability-and-limits). You're *probably* not going to run into any issues, but it's possible. Especially if you end up calling an everything-purge often and you're on a free plan, or have a lot of sites running on the same Cloudflare account.
+> Be aware of the [rate limits on the API](https://developers.cloudflare.com/cache/how-to/purge-cache/#availability-and-limits). This package handles single-request limits automatically, but it does not take into account the per-account limits. You're *probably* not going to run into any issues, but it's possible. Especially if you end up calling an everything-purge often and you're on a free plan, or have a lot of sites running on the same Cloudflare account.
 
 ## Configuration
 

--- a/config/cloudflare-purge.php
+++ b/config/cloudflare-purge.php
@@ -16,4 +16,10 @@ return [
         NavSaved::class,
         StaticCacheCleared::class,
     ],
+
+    'rate-limits' => [
+        'single-file' => [
+            'per-request' => env('CLOUDFLARE_RATE_LIMIT_SINGLE_FILE_PER_REQUEST', 100),
+        ],
+    ],
 ];

--- a/src/Integrations/Cloudflare.php
+++ b/src/Integrations/Cloudflare.php
@@ -26,7 +26,7 @@ class Cloudflare
                 $rateLimit = config('cloudflare-purge.rate-limits.single-file.per-request', 100);
                 if (count($files) > $rateLimit) {
                     // If there are more than N files, run them individually in chunks
-                    foreach(array_chunk($files, $rateLimit) as $chunk) {
+                    foreach (array_chunk($files, $rateLimit) as $chunk) {
                         $this->purge($zone, $chunk);
                     }
                 } else {

--- a/src/Integrations/Cloudflare.php
+++ b/src/Integrations/Cloudflare.php
@@ -23,7 +23,15 @@ class Cloudflare
             $options['purge_everything'] = true;
         } else {
             if ($files) {
-                $options['files'] = $files;
+                $rateLimit = config('cloudflare-purge.rate-limits.single-file.per-request', 100);
+                if (count($files) > $rateLimit) {
+                    // If there are more than N files, run them individually in chunks
+                    foreach(array_chunk($files, $rateLimit) as $chunk) {
+                        $this->purge($zone, $chunk);
+                    }
+                } else {
+                    $options['files'] = $files;
+                }
             }
             if ($tags) {
                 $options['tags'] = $tags;


### PR DESCRIPTION
This PR allows for more than 100 single URLs to be cleared at once, by chunking the requests. We've seen this happen on certain sites that update a lot of products at the same time.